### PR TITLE
GPII-4140: Update to node12 and renamed as scoped package @gpii/ref-array

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "array",
     "ref"
   ],
-  "version": "1.2.0",
+  "version": "2.0.0",
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "repository": {
     "type": "git",
@@ -14,16 +14,16 @@
   "main": "./lib/array.js",
   "license": "MIT",
   "scripts": {
-    "test": "node-gyp rebuild --directory test && mocha -gc --reporter spec"
+    "test": "node-gyp rebuild --directory test && mocha -gc-global --expose-gc --reporter spec"
   },
   "dependencies": {
     "array-index": "1",
-    "debug": "2",
-    "ref": "1"
+    "debug": "4",
+    "ref": "lxe/ref#node-12"
   },
   "devDependencies": {
     "bindings": "1",
-    "mocha": "3",
+    "mocha": "6",
     "nan": "2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "array-index": "1",
     "debug": "4",
-    "ref": "lxe/ref#node-12"
+    "ref": "javihernandez/ref#node-12"
   },
   "devDependencies": {
     "bindings": "1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "array-index": "1",
     "debug": "4",
-    "@gpii/ref": "2.0.0"
+    "ref": "javihernandez/ref#GPII-4140"
   },
   "devDependencies": {
     "bindings": "1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ref-array",
+  "name": "@gpii/ref-array",
   "description": "Create C \"array\" instances on top of Buffers",
   "keywords": [
     "array",
@@ -9,7 +9,7 @@
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "repository": {
     "type": "git",
-    "url": "git://github.com/TooTallNate/ref-array.git"
+    "url": "git://github.com/GPII/ref-array.git"
   },
   "main": "./lib/array.js",
   "license": "MIT",
@@ -19,7 +19,7 @@
   "dependencies": {
     "array-index": "1",
     "debug": "4",
-    "ref": "javihernandez/ref#node-12"
+    "@gpii/ref": "2.0.0"
   },
   "devDependencies": {
     "bindings": "1",


### PR DESCRIPTION
Depends on https://github.com/GPII/ref/pull/1